### PR TITLE
[Feat] 공통 예외 처리 모듈 구성

### DIFF
--- a/src/main/java/com/shcho/shBlog/libs/dto/ExceptionResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/libs/dto/ExceptionResponseDto.java
@@ -1,0 +1,24 @@
+package com.shcho.shBlog.libs.dto;
+
+public record ExceptionResponseDto(
+        Integer status,
+        String message,
+        String code,
+        String field
+) {
+    public static ExceptionResponseDto ofFull(Integer status, String message, String code, String field) {
+        return new ExceptionResponseDto(status, message, code, field);
+    }
+
+    public static ExceptionResponseDto ofCode(Integer status, String message, String code) {
+        return new ExceptionResponseDto(status, message, code, null);
+    }
+
+    public static ExceptionResponseDto ofValidation(Integer status, String message, String field) {
+        return new ExceptionResponseDto(status, message, null, field);
+    }
+
+    public static ExceptionResponseDto ofSimple(Integer status, String message) {
+        return new ExceptionResponseDto(status, message, null, null);
+    }
+}

--- a/src/main/java/com/shcho/shBlog/libs/exception/CustomException.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.shcho.shBlog.libs.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package com.shcho.shBlog.libs.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    /* 404 NOT_FOUND */
+    USER_NOT_FOUND(404, "USER_001", "유저를 찾을 수 없습니다."),
+
+    /* 500 INTERNAL_SERVER_ERROR */
+    INTERNAL_SERVER_ERROR(500, "COMMON_500", "서버 오류가 발생했습니다.");
+
+    private final Integer httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/shcho/shBlog/libs/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.shcho.shBlog.libs.exception;
+
+import com.shcho.shBlog.libs.dto.ExceptionResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    // CustomException 처리 - ErrorCode에 정의된 예외 반환
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ExceptionResponseDto> handleCustomException(CustomException e) {
+        log.error("CustomException 발생: {}", e.getMessage());
+        var errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ExceptionResponseDto.ofCode(
+                        errorCode.getHttpStatus(),
+                        errorCode.getMessage(),
+                        errorCode.getCode()
+                ));
+    }
+
+    // RuntimeException 처리 - 서버 내부 오류 반환
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ExceptionResponseDto> handleRuntimeException(RuntimeException e) {
+        log.error("RuntimeException 발생: ", e);
+        var errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ExceptionResponseDto.ofCode(
+                        errorCode.getHttpStatus(),
+                        errorCode.getMessage(),
+                        errorCode.getCode()
+                ));
+    }
+
+    // @Valid, @Validated 관련 Validation 오류 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponseDto> handleValidationException(MethodArgumentNotValidException e) {
+        log.error("Validation 오류 발생: {}", e.getMessage());
+
+        FieldError fieldError = e.getBindingResult().getFieldError();
+        String message = (fieldError != null) ? fieldError.getDefaultMessage() : "잘못된 요청입니다.";
+        String field = (fieldError != null) ? fieldError.getField() : null;
+
+        return ResponseEntity
+                .badRequest()
+                .body(ExceptionResponseDto.ofValidation(400, message, field));
+    }
+}


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] 공통 예외 처리 모듈 구성

## ✅ 작업 내용

- 프로젝트 전반에서 발생하는 예외를 일관된 구조로 처리할 수 있도록 공통 예외 처리 모듈 구성
- 사용자 정의 예외(CustomException) 및 예외 코드(ErrorCode) 기반 처리
- 전역 예외 처리 핸들러(GlobalExceptionHandler)를 통해 JSON 응답 통일
- Validation 오류(MethodArgumentNotValidException) 처리 추가

## 🔧 변경사항

- `ExceptionResponseDto` (record)
- `ErrorCode` enum 정의
- `CustomException` 정의
- `GlobalExceptionHandler` 구현
- 예외 응답 포맷을 status, message, code, field 구조로 통일

## 📌 관련 이슈

- close #1 

## 📎 참고 자료
- [Baeldung - Exception Handling for REST with Spring](https://www.baeldung.com/exception-handling-for-rest-with-spring)