### PR TITLE
[Feat] User 엔티티 및 Repository 구현

### DIFF
--- a/src/main/java/com/shcho/shBlog/ShBlogApplication.java
+++ b/src/main/java/com/shcho/shBlog/ShBlogApplication.java
@@ -2,8 +2,10 @@ package com.shcho.shBlog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ShBlogApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/shcho/shBlog/common/entity/BaseEntity.java
+++ b/src/main/java/com/shcho/shBlog/common/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.shcho.shBlog.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
@@ -9,9 +9,11 @@ public enum ErrorCode {
 
     /* 404 NOT_FOUND */
     USER_NOT_FOUND(404, "USER_001", "유저를 찾을 수 없습니다."),
+    ALREADY_DELETED_USER(404, "USER_002", "이미 삭제된 유저 입니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
     INTERNAL_SERVER_ERROR(500, "COMMON_500", "서버 오류가 발생했습니다.");
+
 
     private final Integer httpStatus;
     private final String code;

--- a/src/main/java/com/shcho/shBlog/user/entity/Role.java
+++ b/src/main/java/com/shcho/shBlog/user/entity/Role.java
@@ -1,0 +1,5 @@
+package com.shcho.shBlog.user.entity;
+
+public enum Role {
+    ADMIN, USER
+}

--- a/src/main/java/com/shcho/shBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/shBlog/user/entity/User.java
@@ -1,0 +1,80 @@
+package com.shcho.shBlog.user.entity;
+
+import com.shcho.shBlog.common.entity.BaseEntity;
+import com.shcho.shBlog.libs.exception.CustomException;
+import com.shcho.shBlog.libs.exception.ErrorCode;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(unique = true)
+    private String nickname;
+
+    @Column(unique = true)
+    private String email;
+
+    @Column
+    String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(50)")
+    private Role role;
+
+    @Column
+    private LocalDateTime deletedAt;
+
+    public void updateUsername(String username) {
+        this.username = username;
+    }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void withdraw() {
+        if (this.deletedAt != null) {
+            throw new CustomException(ErrorCode.ALREADY_DELETED_USER);
+        }
+        this.deletedAt = LocalDateTime.now();
+        this.username = "DELETED_" + this.username;
+        this.password = null;
+        this.nickname = null;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}

--- a/src/main/java/com/shcho/shBlog/user/repository/UserRepository.java
+++ b/src/main/java/com/shcho/shBlog/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.shcho.shBlog.user.repository;
+
+import com.shcho.shBlog.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] User 엔티티 및 Repository 구현

## ✅ 작업 내용
- 개인 블로그 플랫폼용 User 엔티티 생성
- 기본 필드(username, password, nickname, email, profileImageUrl, role, deletedAt) 설계
- BaseEntity 상속 및 JPA Auditing 적용
- withdraw() 메서드를 통한 soft delete 로직 구현
- UserRepository 인터페이스 생성

## 🔧 변경사항
- User.java 생성 (com.shcho.shBlog.user.entity)
- UserRepository.java 생성 (com.shcho.shBlog.user.repository)
- Role.java 생성 (USER, ADMIN 포함)
- ErrorCode.java에 사용자 관련 에러 추가 (USER_NOT_FOUND, ALREADY_DELETED_USER)
- BaseEntity.java 위치 common.entity로 이동 및 적용

## 📌 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요 -->
- close #4 
