### PR TITLE
[Feat] 프로필 이미지 등록/수정/삭제 (MinIO 연동)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+	// minio
+	implementation 'io.minio:minio:8.5.7'
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/com/shcho/shBlog/common/config/MinioConfig.java
+++ b/src/main/java/com/shcho/shBlog/common/config/MinioConfig.java
@@ -1,0 +1,29 @@
+package com.shcho.shBlog.common.config;
+
+import io.minio.MinioClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class MinioConfig {
+
+    @Value("${minio.url}")
+    private String url;
+
+    @Value("${minio.access-key}")
+    private String accessKey;
+
+    @Value("${minio.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public MinioClient minioClient() {
+        return MinioClient.builder()
+                .endpoint(url)
+                .credentials(accessKey, secretKey)
+                .build();
+    }
+}

--- a/src/main/java/com/shcho/shBlog/common/controller/FileUploadController.java
+++ b/src/main/java/com/shcho/shBlog/common/controller/FileUploadController.java
@@ -1,0 +1,31 @@
+package com.shcho.shBlog.common.controller;
+
+import com.shcho.shBlog.auth.CustomUserDetails;
+import com.shcho.shBlog.common.dto.FileUploadResponseDto;
+import com.shcho.shBlog.common.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/files")
+public class FileUploadController {
+
+    private final S3Service s3Service;
+
+    @PostMapping("/upload")
+    public ResponseEntity<FileUploadResponseDto> uploadFile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("type") String type
+    ) {
+        String username = userDetails.getUsername();
+        return ResponseEntity.ok(s3Service.uploadByType(file, type, username));
+    }
+}

--- a/src/main/java/com/shcho/shBlog/common/dto/FileUploadResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/common/dto/FileUploadResponseDto.java
@@ -1,0 +1,9 @@
+package com.shcho.shBlog.common.dto;
+
+public record FileUploadResponseDto (
+        String fileUrl
+){
+    public static FileUploadResponseDto from(String fileUrl){
+        return new FileUploadResponseDto(fileUrl);
+    }
+}

--- a/src/main/java/com/shcho/shBlog/common/service/S3Service.java
+++ b/src/main/java/com/shcho/shBlog/common/service/S3Service.java
@@ -1,0 +1,94 @@
+package com.shcho.shBlog.common.service;
+
+import com.shcho.shBlog.common.dto.FileUploadResponseDto;
+import com.shcho.shBlog.libs.exception.CustomException;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+import static com.shcho.shBlog.libs.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Service {
+
+    private final MinioClient minioClient;
+
+    @Value("${minio.bucket}")
+    private String bucket;
+
+    public FileUploadResponseDto uploadByType(MultipartFile file, String type, String username) {
+        if ("image".equalsIgnoreCase(type)) {
+            return uploadImage(file, type, username);
+        } else if ("file".equalsIgnoreCase(type)) {
+            return uploadFile(file, type, username);
+        } else {
+            throw new CustomException(INVALID_FILE_TYPE);
+        }
+    }
+
+    private FileUploadResponseDto uploadImage(MultipartFile file, String dir, String username) {
+        validateImageExtension(file);
+        return upload(file, dir, username);
+    }
+
+    private FileUploadResponseDto uploadFile(MultipartFile file, String dir, String username) {
+        // TODO : 필요시 일반 파일 확장자 검증 추가
+        return upload(file, dir, username);
+    }
+
+    private FileUploadResponseDto upload(MultipartFile file, String dir, String username) {
+        try {
+            String originalFilename = file.getOriginalFilename();
+            String fileExtension = getFileExtension(originalFilename);
+
+            String uuid = UUID.randomUUID().toString();
+            String fileName = String.format("%s/%s-%s%s", dir, username, uuid, fileExtension);
+
+            minioClient.putObject(
+                    PutObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(fileName)
+                            .stream(file.getInputStream(), file.getSize(), -1L)
+                            .contentType(file.getContentType())
+                            .build()
+            );
+
+            String url = String.format("https://minio-api.csh980116.synology.me/shblog/%s", fileName);
+            return FileUploadResponseDto.from(url);
+        } catch (Exception e) {
+            log.error("[Minio] 파일 업로드 실패:", e);
+            throw new CustomException(FILE_UPLOAD_FAIL);
+        }
+    }
+
+    private void validateImageExtension(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null) {
+            throw new CustomException(INVALID_IMAGE_FORMAT);
+        }
+
+        String ext = getFileExtension(originalFilename).toLowerCase();
+
+        // 허용된 이미지 확장자
+        if (!(ext.equals(".jpg") || ext.equals(".jpeg") || ext.equals(".png") || ext.equals(".gif"))) {
+            throw new CustomException(INVALID_IMAGE_FORMAT);
+        }
+    }
+
+
+    private String getFileExtension(String originalFilename) {
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            throw new CustomException(INVALID_FILE_FORMAT);
+        }
+        return originalFilename.substring(originalFilename.lastIndexOf("."));
+    }
+
+}

--- a/src/main/java/com/shcho/shBlog/common/service/S3Service.java
+++ b/src/main/java/com/shcho/shBlog/common/service/S3Service.java
@@ -24,6 +24,9 @@ public class S3Service {
     @Value("${minio.bucket}")
     private String bucket;
 
+    @Value("${custom.s3.url}")
+    private String minioBaseUrl;
+
     public FileUploadResponseDto uploadByType(MultipartFile file, String type, String username) {
         if ("image".equalsIgnoreCase(type)) {
             return uploadImage(file, type, username);
@@ -61,7 +64,7 @@ public class S3Service {
                             .build()
             );
 
-            String url = String.format("https://minio-api.csh980116.synology.me/shblog/%s", fileName);
+            String url = String.format("%s/%s/%s", minioBaseUrl, bucket, fileName);
             return FileUploadResponseDto.from(url);
         } catch (Exception e) {
             log.error("[Minio] 파일 업로드 실패:", e);

--- a/src/main/java/com/shcho/shBlog/common/service/S3Service.java
+++ b/src/main/java/com/shcho/shBlog/common/service/S3Service.java
@@ -4,12 +4,14 @@ import com.shcho.shBlog.common.dto.FileUploadResponseDto;
 import com.shcho.shBlog.libs.exception.CustomException;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
+import io.minio.RemoveObjectArgs;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.net.URI;
 import java.util.UUID;
 
 import static com.shcho.shBlog.libs.exception.ErrorCode.*;
@@ -34,6 +36,31 @@ public class S3Service {
             return uploadFile(file, type, username);
         } else {
             throw new CustomException(INVALID_FILE_TYPE);
+        }
+    }
+
+    public void deleteFileByUrl(String imageUrl) {
+        try {
+            URI uri = URI.create(imageUrl);
+            String path = uri.getPath();
+            String[] parts = path.split("/", 3);
+
+            if (parts.length < 3) {
+                throw new CustomException(INVALID_FILE_URL);
+            }
+
+            String bucketName = parts[1];
+            String objectName = parts[2];
+
+            minioClient.removeObject(
+                    RemoveObjectArgs.builder()
+                            .bucket(bucketName)
+                            .object(objectName)
+                            .build()
+            );
+            log.info("[Minio] 파일 삭제 성공: {}", objectName);
+        } catch (Exception e) {
+            log.error("[Minio] 파일 삭제 실패: {}", e.getMessage());
         }
     }
 

--- a/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
@@ -16,10 +16,16 @@ public enum ErrorCode {
     DUPLICATED_EMAIL(409, "USER_004", "이미 사용 중인 이메일입니다."),
     DUPLICATED_NICKNAME(409, "USER_005", "이미 사용 중인 닉네임입니다."),
 
+    /* 400 BAD_REQUEST */
+    INVALID_IMAGE_FORMAT(400, "FILE_001", "이미지 형식이 올바르지 않습니다. (jpg/jpeg/png/gif)"),
+    INVALID_FILE_FORMAT(400, "FILE_002", "파일 형식이 올바르지 않습니다."),
+    INVALID_FILE_TYPE(400, "FILE_003", "파일 타입이 잘못되었습니다."),
+
     /* 401 UNAUTHORIZED */
     INVALID_USERNAME_OR_PASSWORD(401, "AUTH_001", "아이디 또는 비밀번호가 올바르지 않습니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
+    FILE_UPLOAD_FAIL(500, "FILE_500", "파일 업로드에 실패했습니다."),
     INTERNAL_SERVER_ERROR(500, "COMMON_500", "서버 오류가 발생했습니다."),
     JWT_KEY_ERROR(500, "AUTH_500", "JWT 키가 유효하지 않습니다.");
 

--- a/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     INVALID_IMAGE_FORMAT(400, "FILE_001", "이미지 형식이 올바르지 않습니다. (jpg/jpeg/png/gif)"),
     INVALID_FILE_FORMAT(400, "FILE_002", "파일 형식이 올바르지 않습니다."),
     INVALID_FILE_TYPE(400, "FILE_003", "파일 타입이 잘못되었습니다."),
+    INVALID_FILE_URL(400, "FILE_004" , "파일 url이 잘못되었습니다." ),
 
     /* 401 UNAUTHORIZED */
     INVALID_USERNAME_OR_PASSWORD(401, "AUTH_001", "아이디 또는 비밀번호가 올바르지 않습니다."),

--- a/src/main/java/com/shcho/shBlog/user/controller/UserController.java
+++ b/src/main/java/com/shcho/shBlog/user/controller/UserController.java
@@ -49,5 +49,24 @@ public class UserController {
 
         return ResponseEntity.ok(responseDto);
     }
+
+    @PutMapping("/profile")
+    public ResponseEntity<String> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserProfileRequestDto requestDto
+    ) {
+        Long userId = userDetails.getUser().getUserId();
+        userService.updateProfileImage(userId, requestDto.profileImageUrl());
+        return ResponseEntity.ok("프로필 이미지 등록 완료");
+    }
+
+    @DeleteMapping("/profile")
+    public ResponseEntity<String> deleteProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getUserId();
+        userService.deleteProfileImage(userId);
+        return ResponseEntity.ok("프로필 이미지 삭제 완료");
+    }
 }
 

--- a/src/main/java/com/shcho/shBlog/user/controller/UserController.java
+++ b/src/main/java/com/shcho/shBlog/user/controller/UserController.java
@@ -50,7 +50,7 @@ public class UserController {
         return ResponseEntity.ok(responseDto);
     }
 
-    @PutMapping("/profile")
+    @PatchMapping("/profile")
     public ResponseEntity<String> updateProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UserProfileRequestDto requestDto

--- a/src/main/java/com/shcho/shBlog/user/dto/UserProfileRequestDto.java
+++ b/src/main/java/com/shcho/shBlog/user/dto/UserProfileRequestDto.java
@@ -1,0 +1,8 @@
+package com.shcho.shBlog.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserProfileRequestDto(
+        @NotBlank String profileImageUrl
+) {
+}

--- a/src/main/java/com/shcho/shBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/shBlog/user/entity/User.java
@@ -74,6 +74,10 @@ public class User extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public void deleteProfileImageUrl() {
+        this.profileImageUrl = null;
+    }
+
     public void withdraw() {
         if (this.deletedAt != null) {
             throw new CustomException(ErrorCode.ALREADY_DELETED_USER);

--- a/src/main/java/com/shcho/shBlog/user/service/UserService.java
+++ b/src/main/java/com/shcho/shBlog/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.shcho.shBlog.user.service;
 
+import com.shcho.shBlog.common.service.S3Service;
 import com.shcho.shBlog.common.util.JwtProvider;
 import com.shcho.shBlog.libs.exception.CustomException;
 import com.shcho.shBlog.user.dto.UserSignInRequestDto;
@@ -21,6 +22,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final S3Service s3Service;
 
     @Transactional
     public User signUp(@Valid UserSignUpRequestDto requestDto) {
@@ -70,6 +72,32 @@ public class UserService {
     private boolean isUnmatchedPassword(String username, String password) {
         User user = userRepository.getReferenceByUsername(username);
         return !passwordEncoder.matches(password, user.getPassword());
+    }
+
+    @Transactional
+    public void updateProfileImage(Long userId, String newImageUrl) {
+        User user = userRepository.getReferenceById(userId);
+
+        deleteOldImageUrl(user);
+
+        user.updateProfileImageUrl(newImageUrl);
+    }
+
+    @Transactional
+    public void deleteProfileImage(Long userId) {
+        User user = userRepository.getReferenceById(userId);
+
+        deleteOldImageUrl(user);
+
+        user.deleteProfileImageUrl();
+    }
+
+    private void deleteOldImageUrl(User user) {
+        String oldImageUrl = user.getProfileImageUrl();
+
+        if(oldImageUrl != null && !oldImageUrl.isBlank()) {
+            s3Service.deleteFileByUrl(oldImageUrl);
+        }
     }
 
     public String getUserToken(User user) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,12 @@ spring:
         format_sql: true
         show_sql: true
 
+minio:
+  url: ${MINIO_URL}
+  access-key: ${MINIO_ACCESS_KEY}
+  secret-key: ${MINIO_SECRET_KEY}
+  bucket: shblog
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,7 @@ logging:
 
 jwt:
   secret: ${JWT_SECRET}
+
+custom:
+  s3:
+    url: https://minio.boottalk.site

--- a/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.shcho.shBlog.user.service;
 
+import com.shcho.shBlog.common.service.S3Service;
 import com.shcho.shBlog.libs.exception.CustomException;
 import com.shcho.shBlog.libs.exception.ErrorCode;
 import com.shcho.shBlog.user.dto.UserSignInRequestDto;
@@ -17,8 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static com.shcho.shBlog.libs.exception.ErrorCode.*;
 import static com.shcho.shBlog.user.entity.Role.USER;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @DisplayName("User Service Unit Test")
@@ -29,6 +29,9 @@ class UserServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private S3Service s3Service;
 
     @InjectMocks
     private UserService userService;
@@ -203,5 +206,111 @@ class UserServiceTest {
 
     private UserSignInRequestDto createSignInRequest(String username, String password) {
         return new UserSignInRequestDto(username, password);
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업데이트 성공")
+    void updateUserProfileImageSuccess() {
+        // given
+        Long userId = 1L;
+        String newImageUrl = "www.minio.com/new.jpg";
+        String oldImageUrl = "www.minio.com/old.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(oldImageUrl)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        userService.updateProfileImage(userId, newImageUrl);
+
+        // then
+        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
+        assertEquals(newImageUrl, user.getProfileImageUrl());
+
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업데이트 성공 - 기존 이미지 없음")
+    void updateUserProfileImageWithoutOldImage() {
+        // given
+        Long userId = 1L;
+        String newImageUrl = "www.minio.com/new.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(null)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        userService.updateProfileImage(userId, newImageUrl);
+        verify(s3Service, never()).deleteFileByUrl(newImageUrl);
+    }
+
+    @Test
+    @DisplayName("프로필 사진 삭제 성공")
+    void deleteUserProfileImageSuccess() {
+        // given
+        Long userId = 1L;
+        String oldImageUrl = "www.minio.com/old.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(oldImageUrl)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        userService.deleteProfileImage(userId);
+
+        // then
+        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
+        assertNull(user.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("프로필 사진 삭제 - 기존 이미지 없음")
+    void deleteUserProfileImageWithoutOldImage() {
+        // given
+        Long userId = 1L;
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(null) // 이미지 없음
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        userService.deleteProfileImage(userId);
+
+        // then
+        verify(s3Service, never()).deleteFileByUrl(anyString());
+        assertNull(user.getProfileImageUrl());
     }
 }


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] 프로필 이미지 등록/수정/삭제 (MinIO 연동)

## ✅ 작업 내용
- Minio와 연동하여 프로필 이미지 업로드, 수정, 삭제 기능을 구현함
- User 엔티티에 프로필 이미지 URL을 저장하고, 변경 시 기본 이미지를 Minio에서 삭제하도록 처리

## 🔧 변경사항
- `S3Service`
  - 파일 업로드 (`uploadByType`)
  - 파일 삭제 (`deleteFileByUrl`)
- `UserService`
  - `updateProfileImage(Long userId, String newImageUrl)`
  - `deleteProfileImage(Long userId)`
- `UserController`
  - `PATCH /api/auth/profile` → 프로필 이미지 등록/수정
  - `DELETE /api/auth/profile` → 프로필 이미지 삭제
- `User` 엔티티
  - `profileImageUrl` 필드 추가
  - `updateProfileImageUrl`, `deleteProfileImageUrl` 메서드 추가
- 단위 테스트 (`UserServiceTest`)
  - 회원가입/로그인 성공 및 예외 처리
  - 프로필 이미지 등록/수정/삭제 테스트

## 📌 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요 -->
- close #14 

## ✅ 테스트 결과
- 단위 테스트 통과 (`UserServiceTest`)
- MinIO 실제 연동 테스트 성공
- 기존 이미지 삭제 및 신규 URL 반영 정상 동작 확인
