### PR TITLE
[Feat] 회원 정보 수정 API

### DIFF
--- a/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
@@ -46,5 +46,5 @@ public class MyPageController {
         return ResponseEntity.ok("프로필 이미지 삭제 완료");
     }
 
-
+    // TODO :
 }

--- a/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
@@ -1,0 +1,50 @@
+package com.shcho.shBlog.myPage.controller;
+
+import com.shcho.shBlog.auth.CustomUserDetails;
+import com.shcho.shBlog.myPage.service.MyPageService;
+import com.shcho.shBlog.myPage.dto.UserInfoResponseDto;
+import com.shcho.shBlog.user.dto.UserProfileRequestDto;
+import com.shcho.shBlog.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/myPage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private MyPageService myPageService;
+
+    @GetMapping
+    public ResponseEntity<UserInfoResponseDto> getMyPage(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User user = userDetails.getUser();
+        UserInfoResponseDto responseDto = UserInfoResponseDto.from(user);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @PatchMapping("/profile")
+    public ResponseEntity<String> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserProfileRequestDto requestDto
+    ) {
+        Long userId = userDetails.getUser().getUserId();
+        myPageService.updateProfileImage(userId, requestDto.profileImageUrl());
+        return ResponseEntity.ok("프로필 이미지 등록 완료");
+    }
+
+    @DeleteMapping("/profile")
+    public ResponseEntity<String> deleteProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getUserId();
+        myPageService.deleteProfileImage(userId);
+        return ResponseEntity.ok("프로필 이미지 삭제 완료");
+    }
+
+
+}

--- a/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
@@ -1,6 +1,7 @@
 package com.shcho.shBlog.myPage.controller;
 
 import com.shcho.shBlog.auth.CustomUserDetails;
+import com.shcho.shBlog.myPage.dto.UserPasswordUpdateRequestDto;
 import com.shcho.shBlog.myPage.service.MyPageService;
 import com.shcho.shBlog.myPage.dto.UserInfoResponseDto;
 import com.shcho.shBlog.user.dto.UserProfileRequestDto;
@@ -46,5 +47,32 @@ public class MyPageController {
         return ResponseEntity.ok("프로필 이미지 삭제 완료");
     }
 
-    // TODO :
+    @GetMapping("/nickname/check")
+    public ResponseEntity<Boolean> checkNickname(
+            @RequestParam String nickname
+    ) {
+        boolean exists = myPageService.existsByNickname(nickname);
+        return ResponseEntity.ok(exists);
+    }
+
+    @PatchMapping("/nickname")
+    public ResponseEntity<String> updateNickname(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam String nickname
+    ) {
+        Long userId = userDetails.getUser().getUserId();
+        myPageService.updateNickname(userId, nickname);
+
+        return ResponseEntity.ok("닉네임 변경이 완료 되었습니다.");
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<String> updatePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserPasswordUpdateRequestDto requestDto
+            ) {
+        Long userId = userDetails.getUser().getUserId();
+        myPageService.updatePassword(userId, requestDto.currentPassword(), requestDto.newPassword());
+        return ResponseEntity.ok("비밀번호 변경이 완료 되었습니다.");
+    }
 }

--- a/src/main/java/com/shcho/shBlog/myPage/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/myPage/dto/UserInfoResponseDto.java
@@ -1,4 +1,4 @@
-package com.shcho.shBlog.user.dto;
+package com.shcho.shBlog.myPage.dto;
 
 import com.shcho.shBlog.user.entity.User;
 

--- a/src/main/java/com/shcho/shBlog/myPage/dto/UserPasswordUpdateRequestDto.java
+++ b/src/main/java/com/shcho/shBlog/myPage/dto/UserPasswordUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package com.shcho.shBlog.myPage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserPasswordUpdateRequestDto(
+        @NotBlank String currentPassword,
+        @NotBlank String newPassword
+) {
+}

--- a/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
+++ b/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
@@ -1,11 +1,16 @@
 package com.shcho.shBlog.myPage.service;
 
 import com.shcho.shBlog.common.service.S3Service;
+import com.shcho.shBlog.libs.exception.CustomException;
+import com.shcho.shBlog.libs.exception.ErrorCode;
 import com.shcho.shBlog.user.entity.User;
 import com.shcho.shBlog.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.shcho.shBlog.libs.exception.ErrorCode.DUPLICATED_NICKNAME;
 
 @Service
 @RequiredArgsConstructor
@@ -13,6 +18,7 @@ public class MyPageService {
 
     private final UserRepository userRepository;
     private final S3Service s3Service;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public void updateProfileImage(Long userId, String newImageUrl) {
@@ -38,5 +44,32 @@ public class MyPageService {
         if(oldImageUrl != null && !oldImageUrl.isBlank()) {
             s3Service.deleteFileByUrl(oldImageUrl);
         }
+    }
+
+    public boolean existsByNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
+    @Transactional
+    public void updateNickname(Long userId, String newNickname) {
+        User user = userRepository.getReferenceById(userId);
+
+        if(userRepository.existsByNickname(newNickname)) {
+            throw new CustomException(DUPLICATED_NICKNAME);
+        }
+
+        user.updateNickname(newNickname);
+    }
+
+    @Transactional
+    public void updatePassword(Long userId, String currentPassword, String newPassword) {
+        User user = userRepository.getReferenceById(userId);
+
+        if(!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_USERNAME_OR_PASSWORD);
+        }
+
+        String encodedPassword = passwordEncoder.encode(newPassword);
+        user.updatePassword(encodedPassword);
     }
 }

--- a/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
+++ b/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
@@ -1,0 +1,42 @@
+package com.shcho.shBlog.myPage.service;
+
+import com.shcho.shBlog.common.service.S3Service;
+import com.shcho.shBlog.user.entity.User;
+import com.shcho.shBlog.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public void updateProfileImage(Long userId, String newImageUrl) {
+        User user = userRepository.getReferenceById(userId);
+
+        deleteOldImageUrl(user);
+
+        user.updateProfileImageUrl(newImageUrl);
+    }
+
+    @Transactional
+    public void deleteProfileImage(Long userId) {
+        User user = userRepository.getReferenceById(userId);
+
+        deleteOldImageUrl(user);
+
+        user.deleteProfileImageUrl();
+    }
+
+    private void deleteOldImageUrl(User user) {
+        String oldImageUrl = user.getProfileImageUrl();
+
+        if(oldImageUrl != null && !oldImageUrl.isBlank()) {
+            s3Service.deleteFileByUrl(oldImageUrl);
+        }
+    }
+}

--- a/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
+++ b/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
@@ -2,7 +2,6 @@ package com.shcho.shBlog.myPage.service;
 
 import com.shcho.shBlog.common.service.S3Service;
 import com.shcho.shBlog.libs.exception.CustomException;
-import com.shcho.shBlog.libs.exception.ErrorCode;
 import com.shcho.shBlog.user.entity.User;
 import com.shcho.shBlog.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.shcho.shBlog.libs.exception.ErrorCode.DUPLICATED_NICKNAME;
+import static com.shcho.shBlog.libs.exception.ErrorCode.INVALID_USERNAME_OR_PASSWORD;
 
 @Service
 @RequiredArgsConstructor
@@ -41,7 +41,7 @@ public class MyPageService {
     private void deleteOldImageUrl(User user) {
         String oldImageUrl = user.getProfileImageUrl();
 
-        if(oldImageUrl != null && !oldImageUrl.isBlank()) {
+        if (oldImageUrl != null && !oldImageUrl.isBlank()) {
             s3Service.deleteFileByUrl(oldImageUrl);
         }
     }
@@ -54,7 +54,7 @@ public class MyPageService {
     public void updateNickname(Long userId, String newNickname) {
         User user = userRepository.getReferenceById(userId);
 
-        if(userRepository.existsByNickname(newNickname)) {
+        if (userRepository.existsByNickname(newNickname)) {
             throw new CustomException(DUPLICATED_NICKNAME);
         }
 
@@ -65,8 +65,8 @@ public class MyPageService {
     public void updatePassword(Long userId, String currentPassword, String newPassword) {
         User user = userRepository.getReferenceById(userId);
 
-        if(!passwordEncoder.matches(currentPassword, user.getPassword())) {
-            throw new CustomException(ErrorCode.INVALID_USERNAME_OR_PASSWORD);
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new CustomException(INVALID_USERNAME_OR_PASSWORD);
         }
 
         String encodedPassword = passwordEncoder.encode(newPassword);

--- a/src/main/java/com/shcho/shBlog/user/controller/UserController.java
+++ b/src/main/java/com/shcho/shBlog/user/controller/UserController.java
@@ -1,14 +1,18 @@
 package com.shcho.shBlog.user.controller;
 
-import com.shcho.shBlog.auth.CustomUserDetails;
-import com.shcho.shBlog.user.dto.*;
+import com.shcho.shBlog.user.dto.UserSignInRequestDto;
+import com.shcho.shBlog.user.dto.UserSignInResponseDto;
+import com.shcho.shBlog.user.dto.UserSignUpRequestDto;
+import com.shcho.shBlog.user.dto.UserSignUpResponseDto;
 import com.shcho.shBlog.user.entity.User;
 import com.shcho.shBlog.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -38,35 +42,6 @@ public class UserController {
         UserSignInResponseDto responseDto = UserSignInResponseDto.of(user, token);
 
         return ResponseEntity.ok(responseDto);
-    }
-
-    @GetMapping("/me")
-    public ResponseEntity<UserInfoResponseDto> getMyInfo(
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        User user = userDetails.getUser();
-        UserInfoResponseDto responseDto = UserInfoResponseDto.from(user);
-
-        return ResponseEntity.ok(responseDto);
-    }
-
-    @PatchMapping("/profile")
-    public ResponseEntity<String> updateProfile(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody UserProfileRequestDto requestDto
-    ) {
-        Long userId = userDetails.getUser().getUserId();
-        userService.updateProfileImage(userId, requestDto.profileImageUrl());
-        return ResponseEntity.ok("프로필 이미지 등록 완료");
-    }
-
-    @DeleteMapping("/profile")
-    public ResponseEntity<String> deleteProfile(
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        Long userId = userDetails.getUser().getUserId();
-        userService.deleteProfileImage(userId);
-        return ResponseEntity.ok("프로필 이미지 삭제 완료");
     }
 }
 

--- a/src/main/java/com/shcho/shBlog/user/service/UserService.java
+++ b/src/main/java/com/shcho/shBlog/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.shcho.shBlog.user.service;
 
-import com.shcho.shBlog.common.service.S3Service;
 import com.shcho.shBlog.common.util.JwtProvider;
 import com.shcho.shBlog.libs.exception.CustomException;
 import com.shcho.shBlog.user.dto.UserSignInRequestDto;
@@ -22,7 +21,6 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
-    private final S3Service s3Service;
 
     @Transactional
     public User signUp(@Valid UserSignUpRequestDto requestDto) {
@@ -74,31 +72,6 @@ public class UserService {
         return !passwordEncoder.matches(password, user.getPassword());
     }
 
-    @Transactional
-    public void updateProfileImage(Long userId, String newImageUrl) {
-        User user = userRepository.getReferenceById(userId);
-
-        deleteOldImageUrl(user);
-
-        user.updateProfileImageUrl(newImageUrl);
-    }
-
-    @Transactional
-    public void deleteProfileImage(Long userId) {
-        User user = userRepository.getReferenceById(userId);
-
-        deleteOldImageUrl(user);
-
-        user.deleteProfileImageUrl();
-    }
-
-    private void deleteOldImageUrl(User user) {
-        String oldImageUrl = user.getProfileImageUrl();
-
-        if(oldImageUrl != null && !oldImageUrl.isBlank()) {
-            s3Service.deleteFileByUrl(oldImageUrl);
-        }
-    }
 
     public String getUserToken(User user) {
         return jwtProvider.createToken(user.getUsername(), user.getRole());

--- a/src/test/java/com/shcho/shBlog/myPage/service/MyPageServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/myPage/service/MyPageServiceTest.java
@@ -1,6 +1,7 @@
 package com.shcho.shBlog.myPage.service;
 
 import com.shcho.shBlog.common.service.S3Service;
+import com.shcho.shBlog.libs.exception.CustomException;
 import com.shcho.shBlog.user.entity.User;
 import com.shcho.shBlog.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -8,13 +9,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static com.shcho.shBlog.libs.exception.ErrorCode.DUPLICATED_NICKNAME;
+import static com.shcho.shBlog.libs.exception.ErrorCode.INVALID_USERNAME_OR_PASSWORD;
 import static com.shcho.shBlog.user.entity.Role.USER;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.never;
 
 @DisplayName("MyPage Service Unit Test")
 class MyPageServiceTest {
@@ -24,6 +26,9 @@ class MyPageServiceTest {
 
     @Mock
     private S3Service s3Service;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @InjectMocks
     private MyPageService myPageService;
@@ -136,5 +141,132 @@ class MyPageServiceTest {
         // then
         verify(s3Service, never()).deleteFileByUrl(anyString());
         assertNull(user.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 확인")
+    void existsNicknameSuccess() {
+        // given
+        String nickname = "existsNickname";
+        when(userRepository.existsByNickname(nickname)).thenReturn(true);
+
+        // when
+        boolean exists = myPageService.existsByNickname(nickname);
+
+        // then
+        assertTrue(exists);
+        verify(userRepository, times(1)).existsByNickname(nickname);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 성공")
+    void updateNicknameSuccess() {
+        // given
+        Long userId = 1L;
+        String newNickname = "newNickname";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("userName")
+                .nickname("oldNickname")
+                .password("encodedPassword")
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+        when(userRepository.existsByNickname(newNickname)).thenReturn(false);
+
+        // when
+        myPageService.updateNickname(userId, newNickname);
+
+        // then
+        assertEquals(newNickname, user.getNickname());
+        verify(userRepository, times(1)).existsByNickname(newNickname);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 실패 - 중복된 닉네임")
+    void updateNicknameFailedDuplicatedNickname() {
+        // given
+        Long userId = 1L;
+        String existsNickname = "existsNickname";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("userName")
+                .nickname("oldNickname")
+                .password("encodedPassword")
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+        when(userRepository.existsByNickname(existsNickname)).thenReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> myPageService.updateNickname(userId, existsNickname));
+
+        assertEquals(DUPLICATED_NICKNAME, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 성공")
+    void updatePasswordSuccess() {
+        // given
+        Long userId = 1L;
+        String oldPassword = "oldPassword";
+        String newPassword = "newPassword";
+
+        String encodedOldPassword = "encodedOldPassword";
+        String encodedNewPassword = "encodedNewPassword";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .password(encodedOldPassword)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+        when(passwordEncoder.matches(oldPassword, user.getPassword())).thenReturn(true);
+        when(passwordEncoder.encode(newPassword)).thenReturn("encodedNewPassword");
+
+        // when
+        myPageService.updatePassword(userId, oldPassword, newPassword);
+
+        // then
+        assertEquals(encodedNewPassword, user.getPassword());
+        verify(passwordEncoder).matches(oldPassword, encodedOldPassword);
+        verify(passwordEncoder).encode(newPassword);
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - 비밀번호 불일치")
+    void updatePasswordFailedUnmatchedPassword() {
+        // given
+        Long userId = 1L;
+        String oldPassword = "oldPassword";
+        String newPassword = "newPassword";
+
+        String encodedOldPassword = passwordEncoder.encode(oldPassword);
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .password(encodedOldPassword)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+        when(passwordEncoder.matches(oldPassword, user.getPassword())).thenReturn(false);
+
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> myPageService.updatePassword(userId, oldPassword, newPassword));
+
+        assertEquals(INVALID_USERNAME_OR_PASSWORD, exception.getErrorCode());
     }
 }

--- a/src/test/java/com/shcho/shBlog/myPage/service/MyPageServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/myPage/service/MyPageServiceTest.java
@@ -1,0 +1,140 @@
+package com.shcho.shBlog.myPage.service;
+
+import com.shcho.shBlog.common.service.S3Service;
+import com.shcho.shBlog.user.entity.User;
+import com.shcho.shBlog.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static com.shcho.shBlog.user.entity.Role.USER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+
+@DisplayName("MyPage Service Unit Test")
+class MyPageServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private MyPageService myPageService;
+
+    public MyPageServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업데이트 성공")
+    void updateUserProfileImageSuccess() {
+        // given
+        Long userId = 1L;
+        String newImageUrl = "www.minio.com/new.jpg";
+        String oldImageUrl = "www.minio.com/old.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(oldImageUrl)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        myPageService.updateProfileImage(userId, newImageUrl);
+
+        // then
+        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
+        assertEquals(newImageUrl, user.getProfileImageUrl());
+
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업데이트 성공 - 기존 이미지 없음")
+    void updateUserProfileImageWithoutOldImage() {
+        // given
+        Long userId = 1L;
+        String newImageUrl = "www.minio.com/new.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(null)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        myPageService.updateProfileImage(userId, newImageUrl);
+        verify(s3Service, never()).deleteFileByUrl(newImageUrl);
+    }
+
+    @Test
+    @DisplayName("프로필 사진 삭제 성공")
+    void deleteUserProfileImageSuccess() {
+        // given
+        Long userId = 1L;
+        String oldImageUrl = "www.minio.com/old.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(oldImageUrl)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        myPageService.deleteProfileImage(userId);
+
+        // then
+        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
+        assertNull(user.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("프로필 사진 삭제 - 기존 이미지 없음")
+    void deleteUserProfileImageWithoutOldImage() {
+        // given
+        Long userId = 1L;
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(null) // 이미지 없음
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        myPageService.deleteProfileImage(userId);
+
+        // then
+        verify(s3Service, never()).deleteFileByUrl(anyString());
+        assertNull(user.getProfileImageUrl());
+    }
+}

--- a/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
@@ -1,11 +1,8 @@
 package com.shcho.shBlog.user.service;
 
-import com.shcho.shBlog.common.service.S3Service;
 import com.shcho.shBlog.libs.exception.CustomException;
-import com.shcho.shBlog.libs.exception.ErrorCode;
 import com.shcho.shBlog.user.dto.UserSignInRequestDto;
 import com.shcho.shBlog.user.dto.UserSignUpRequestDto;
-import com.shcho.shBlog.user.entity.Role;
 import com.shcho.shBlog.user.entity.User;
 import com.shcho.shBlog.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +15,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static com.shcho.shBlog.libs.exception.ErrorCode.*;
 import static com.shcho.shBlog.user.entity.Role.USER;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @DisplayName("User Service Unit Test")

--- a/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
@@ -30,9 +30,6 @@ class UserServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
-    @Mock
-    private S3Service s3Service;
-
     @InjectMocks
     private UserService userService;
 
@@ -208,109 +205,5 @@ class UserServiceTest {
         return new UserSignInRequestDto(username, password);
     }
 
-    @Test
-    @DisplayName("프로필 사진 업데이트 성공")
-    void updateUserProfileImageSuccess() {
-        // given
-        Long userId = 1L;
-        String newImageUrl = "www.minio.com/new.jpg";
-        String oldImageUrl = "www.minio.com/old.jpg";
 
-        User user = User.builder()
-                .userId(userId)
-                .username("existsUsername")
-                .nickname("test")
-                .email("test@email.com")
-                .password("encodedPassword")
-                .profileImageUrl(oldImageUrl)
-                .role(USER)
-                .build();
-
-        when(userRepository.getReferenceById(userId)).thenReturn(user);
-
-        // when
-        userService.updateProfileImage(userId, newImageUrl);
-
-        // then
-        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
-        assertEquals(newImageUrl, user.getProfileImageUrl());
-
-    }
-
-    @Test
-    @DisplayName("프로필 사진 업데이트 성공 - 기존 이미지 없음")
-    void updateUserProfileImageWithoutOldImage() {
-        // given
-        Long userId = 1L;
-        String newImageUrl = "www.minio.com/new.jpg";
-
-        User user = User.builder()
-                .userId(userId)
-                .username("existsUsername")
-                .nickname("test")
-                .email("test@email.com")
-                .password("encodedPassword")
-                .profileImageUrl(null)
-                .role(USER)
-                .build();
-
-        when(userRepository.getReferenceById(userId)).thenReturn(user);
-
-        // when
-        userService.updateProfileImage(userId, newImageUrl);
-        verify(s3Service, never()).deleteFileByUrl(newImageUrl);
-    }
-
-    @Test
-    @DisplayName("프로필 사진 삭제 성공")
-    void deleteUserProfileImageSuccess() {
-        // given
-        Long userId = 1L;
-        String oldImageUrl = "www.minio.com/old.jpg";
-
-        User user = User.builder()
-                .userId(userId)
-                .username("existsUsername")
-                .nickname("test")
-                .email("test@email.com")
-                .password("encodedPassword")
-                .profileImageUrl(oldImageUrl)
-                .role(USER)
-                .build();
-
-        when(userRepository.getReferenceById(userId)).thenReturn(user);
-
-        // when
-        userService.deleteProfileImage(userId);
-
-        // then
-        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
-        assertNull(user.getProfileImageUrl());
-    }
-
-    @Test
-    @DisplayName("프로필 사진 삭제 - 기존 이미지 없음")
-    void deleteUserProfileImageWithoutOldImage() {
-        // given
-        Long userId = 1L;
-
-        User user = User.builder()
-                .userId(userId)
-                .username("existsUsername")
-                .nickname("test")
-                .email("test@email.com")
-                .password("encodedPassword")
-                .profileImageUrl(null) // 이미지 없음
-                .role(USER)
-                .build();
-
-        when(userRepository.getReferenceById(userId)).thenReturn(user);
-
-        // when
-        userService.deleteProfileImage(userId);
-
-        // then
-        verify(s3Service, never()).deleteFileByUrl(anyString());
-        assertNull(user.getProfileImageUrl());
-    }
 }


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] 회원 정보 수정 API

## ✅ 작업 내용
- 회원 정보 수정 API (프로필 사진, 닉네임, 비밀번호 변경) 기능을 구현

## 🔧 변경사항
- `MyPageController`에 회원 정보 수정 관련 엔드포인트 추가
  - [PATCH] `/api/myPage/profile` : 프로필 사진 등록/수정
  - [DELETE] `/api/myPage/profile` : 프로필 사진 삭제
  - [GET] `/api/myPage/nickname/check` : 닉네임 중복 확인
  - [PATCH] `/api/myPage/nickname` : 닉네임 변경
  - [PATCH] `/api/myPage/password` : 비밀번호 변경
- `MyPageService` 로직 추가
  - 닉네임 중복 검사 및 업데이트
  - 비밀번호 검증 및 업데이트
- 단위 테스트 (`MyPageServiceTest`) 작성 완료

## 📌 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요 -->
- close #15