### PR TITLE
[Feat] Category 엔티티 및 CRUD 기능 및 단위 테스트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+	// minio
+	implementation 'io.minio:minio:8.5.7'
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'

--- a/src/main/java/com/shcho/shBlog/category/controller/CategoryController.java
+++ b/src/main/java/com/shcho/shBlog/category/controller/CategoryController.java
@@ -1,0 +1,54 @@
+package com.shcho.shBlog.category.controller;
+
+import com.shcho.shBlog.auth.CustomUserDetails;
+import com.shcho.shBlog.category.dto.CreateCategoryRequestDto;
+import com.shcho.shBlog.category.dto.CreateCategoryResponseDto;
+import com.shcho.shBlog.category.entity.Category;
+import com.shcho.shBlog.category.service.CategoryService;
+import com.shcho.shBlog.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/category")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @PostMapping
+    public ResponseEntity<CreateCategoryResponseDto> createCategory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody CreateCategoryRequestDto requestDto
+    ) {
+        User user = userDetails.getUser();
+        Category newCategory = categoryService.createCategory(user, requestDto);
+
+        return ResponseEntity.ok(CreateCategoryResponseDto.from(user.getUsername(), newCategory));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Category>> getAllCategories(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User user = userDetails.getUser();
+        List<Category> categories = categoryService.getAllCategories(user);
+
+        return ResponseEntity.ok(categories);
+    }
+
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<String> deleteCategory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long categoryId
+    ) {
+        User user = userDetails.getUser();
+        categoryService.deleteCategoryByCategoryId(user, categoryId);
+
+        return ResponseEntity.ok("카테고리가 성공적으로 삭제 되었습니다.");
+    }
+}

--- a/src/main/java/com/shcho/shBlog/category/controller/CategoryController.java
+++ b/src/main/java/com/shcho/shBlog/category/controller/CategoryController.java
@@ -1,6 +1,7 @@
 package com.shcho.shBlog.category.controller;
 
 import com.shcho.shBlog.auth.CustomUserDetails;
+import com.shcho.shBlog.category.dto.CategoryResponseDto;
 import com.shcho.shBlog.category.dto.CreateCategoryRequestDto;
 import com.shcho.shBlog.category.dto.CreateCategoryResponseDto;
 import com.shcho.shBlog.category.entity.Category;
@@ -32,11 +33,14 @@ public class CategoryController {
     }
 
     @GetMapping
-    public ResponseEntity<List<Category>> getAllCategories(
+    public ResponseEntity<List<CategoryResponseDto>> getAllCategories(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         User user = userDetails.getUser();
-        List<Category> categories = categoryService.getAllCategories(user);
+        List<CategoryResponseDto> categories = categoryService.getAllCategories(user)
+                .stream()
+                .map(CategoryResponseDto::from)
+                .toList();
 
         return ResponseEntity.ok(categories);
     }

--- a/src/main/java/com/shcho/shBlog/category/dto/CategoryResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/category/dto/CategoryResponseDto.java
@@ -1,0 +1,17 @@
+package com.shcho.shBlog.category.dto;
+
+import com.shcho.shBlog.category.entity.Category;
+
+public record CategoryResponseDto(
+        Long id,
+        String name,
+        String description
+) {
+    public static CategoryResponseDto from(Category category) {
+        return new CategoryResponseDto(
+                category.getId(),
+                category.getName(),
+                category.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/shcho/shBlog/category/dto/CreateCategoryRequestDto.java
+++ b/src/main/java/com/shcho/shBlog/category/dto/CreateCategoryRequestDto.java
@@ -1,0 +1,7 @@
+package com.shcho.shBlog.category.dto;
+
+public record CreateCategoryRequestDto(
+        String name,
+        String description
+) {
+}

--- a/src/main/java/com/shcho/shBlog/category/dto/CreateCategoryResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/category/dto/CreateCategoryResponseDto.java
@@ -1,0 +1,19 @@
+package com.shcho.shBlog.category.dto;
+
+import com.shcho.shBlog.category.entity.Category;
+
+public record CreateCategoryResponseDto(
+        String userName,
+        Long categoryId,
+        String categoryName,
+        String categoryDescription
+) {
+    public static CreateCategoryResponseDto from(String userName, Category category) {
+        return new CreateCategoryResponseDto(
+                userName,
+                category.getId(),
+                category.getName(),
+                category.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/shcho/shBlog/category/entity/Category.java
+++ b/src/main/java/com/shcho/shBlog/category/entity/Category.java
@@ -1,6 +1,7 @@
 package com.shcho.shBlog.category.entity;
 
 import com.shcho.shBlog.common.entity.BaseEntity;
+import com.shcho.shBlog.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,4 +23,15 @@ public class Category extends BaseEntity {
     private String name;
 
     private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /**
+     * 연관관계 편의 메서드(User.addCategory)를 통해서만 사용해야 한다.
+     */
+    public void setUser(User user) {
+        this.user = user;
+    }
 }

--- a/src/main/java/com/shcho/shBlog/category/entity/Category.java
+++ b/src/main/java/com/shcho/shBlog/category/entity/Category.java
@@ -19,7 +19,7 @@ public class Category extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 50)
+    @Column(nullable = false, length = 50)
     private String name;
 
     private String description;
@@ -28,10 +28,11 @@ public class Category extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    /**
-     * 연관관계 편의 메서드(User.addCategory)를 통해서만 사용해야 한다.
-     */
-    public void setUser(User user) {
-        this.user = user;
+    public static Category of(User user, String name, String description) {
+        return Category.builder()
+                .user(user)
+                .name(name)
+                .description(description)
+                .build();
     }
 }

--- a/src/main/java/com/shcho/shBlog/category/entity/Category.java
+++ b/src/main/java/com/shcho/shBlog/category/entity/Category.java
@@ -1,0 +1,25 @@
+package com.shcho.shBlog.category.entity;
+
+import com.shcho.shBlog.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Category extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String name;
+
+    private String description;
+}

--- a/src/main/java/com/shcho/shBlog/category/repository/CategoryRepository.java
+++ b/src/main/java/com/shcho/shBlog/category/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package com.shcho.shBlog.category.repository;
+
+import com.shcho.shBlog.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findAllByUser_UserIdOrderByNameAsc(Long userId);
+
+    boolean existsByUser_UserIdAndName(Long userId, String name);
+}

--- a/src/main/java/com/shcho/shBlog/category/service/CategoryService.java
+++ b/src/main/java/com/shcho/shBlog/category/service/CategoryService.java
@@ -1,0 +1,50 @@
+package com.shcho.shBlog.category.service;
+
+import com.shcho.shBlog.category.dto.CreateCategoryRequestDto;
+import com.shcho.shBlog.category.entity.Category;
+import com.shcho.shBlog.category.repository.CategoryRepository;
+import com.shcho.shBlog.libs.exception.CustomException;
+import com.shcho.shBlog.user.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.shcho.shBlog.libs.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public Category createCategory(User user, CreateCategoryRequestDto requestDto) {
+
+        if(categoryRepository.existsByUser_UserIdAndName(user.getUserId(), requestDto.name())){
+            throw new CustomException(DUPLICATE_CATEGORY_NAME);
+        }
+
+        Category category = Category.of(user, requestDto.name(), requestDto.description());
+        categoryRepository.save(category);
+        return category;
+    }
+
+    public List<Category> getAllCategories(User user) {
+        Long userId = user.getUserId();
+        return categoryRepository.findAllByUser_UserIdOrderByNameAsc(userId);
+    }
+
+    @Transactional
+    public void deleteCategoryByCategoryId(User user, Long categoryId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CustomException(CATEGORY_NOT_FOUND));
+
+        if (!category.getUser().getUserId().equals(user.getUserId())) {
+            throw new CustomException(FORBIDDEN_CATEGORY_DELETE);
+        }
+
+        categoryRepository.delete(category);
+    }
+}

--- a/src/main/java/com/shcho/shBlog/common/config/MinioConfig.java
+++ b/src/main/java/com/shcho/shBlog/common/config/MinioConfig.java
@@ -1,0 +1,29 @@
+package com.shcho.shBlog.common.config;
+
+import io.minio.MinioClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class MinioConfig {
+
+    @Value("${minio.url}")
+    private String url;
+
+    @Value("${minio.access-key}")
+    private String accessKey;
+
+    @Value("${minio.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public MinioClient minioClient() {
+        return MinioClient.builder()
+                .endpoint(url)
+                .credentials(accessKey, secretKey)
+                .build();
+    }
+}

--- a/src/main/java/com/shcho/shBlog/common/config/SecurityConfig.java
+++ b/src/main/java/com/shcho/shBlog/common/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
-                                "/swagger-ui.html"
+                                "/swagger-ui.html",
+                                "**"
                         ).permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         // 그 외 경로는 인증 필요

--- a/src/main/java/com/shcho/shBlog/common/controller/FileUploadController.java
+++ b/src/main/java/com/shcho/shBlog/common/controller/FileUploadController.java
@@ -1,0 +1,31 @@
+package com.shcho.shBlog.common.controller;
+
+import com.shcho.shBlog.auth.CustomUserDetails;
+import com.shcho.shBlog.common.dto.FileUploadResponseDto;
+import com.shcho.shBlog.common.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/files")
+public class FileUploadController {
+
+    private final S3Service s3Service;
+
+    @PostMapping("/upload")
+    public ResponseEntity<FileUploadResponseDto> uploadFile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("type") String type
+    ) {
+        String username = userDetails.getUsername();
+        return ResponseEntity.ok(s3Service.uploadByType(file, type, username));
+    }
+}

--- a/src/main/java/com/shcho/shBlog/common/dto/FileUploadResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/common/dto/FileUploadResponseDto.java
@@ -1,0 +1,9 @@
+package com.shcho.shBlog.common.dto;
+
+public record FileUploadResponseDto (
+        String fileUrl
+){
+    public static FileUploadResponseDto from(String fileUrl){
+        return new FileUploadResponseDto(fileUrl);
+    }
+}

--- a/src/main/java/com/shcho/shBlog/common/service/S3Service.java
+++ b/src/main/java/com/shcho/shBlog/common/service/S3Service.java
@@ -1,0 +1,94 @@
+package com.shcho.shBlog.common.service;
+
+import com.shcho.shBlog.common.dto.FileUploadResponseDto;
+import com.shcho.shBlog.libs.exception.CustomException;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+import static com.shcho.shBlog.libs.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Service {
+
+    private final MinioClient minioClient;
+
+    @Value("${minio.bucket}")
+    private String bucket;
+
+    public FileUploadResponseDto uploadByType(MultipartFile file, String type, String username) {
+        if ("image".equalsIgnoreCase(type)) {
+            return uploadImage(file, type, username);
+        } else if ("file".equalsIgnoreCase(type)) {
+            return uploadFile(file, type, username);
+        } else {
+            throw new CustomException(INVALID_FILE_TYPE);
+        }
+    }
+
+    private FileUploadResponseDto uploadImage(MultipartFile file, String dir, String username) {
+        validateImageExtension(file);
+        return upload(file, dir, username);
+    }
+
+    private FileUploadResponseDto uploadFile(MultipartFile file, String dir, String username) {
+        // TODO : 필요시 일반 파일 확장자 검증 추가
+        return upload(file, dir, username);
+    }
+
+    private FileUploadResponseDto upload(MultipartFile file, String dir, String username) {
+        try {
+            String originalFilename = file.getOriginalFilename();
+            String fileExtension = getFileExtension(originalFilename);
+
+            String uuid = UUID.randomUUID().toString();
+            String fileName = String.format("%s/%s-%s%s", dir, username, uuid, fileExtension);
+
+            minioClient.putObject(
+                    PutObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(fileName)
+                            .stream(file.getInputStream(), file.getSize(), -1L)
+                            .contentType(file.getContentType())
+                            .build()
+            );
+
+            String url = String.format("https://minio-api.csh980116.synology.me/shblog/%s", fileName);
+            return FileUploadResponseDto.from(url);
+        } catch (Exception e) {
+            log.error("[Minio] 파일 업로드 실패:", e);
+            throw new CustomException(FILE_UPLOAD_FAIL);
+        }
+    }
+
+    private void validateImageExtension(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null) {
+            throw new CustomException(INVALID_IMAGE_FORMAT);
+        }
+
+        String ext = getFileExtension(originalFilename).toLowerCase();
+
+        // 허용된 이미지 확장자
+        if (!(ext.equals(".jpg") || ext.equals(".jpeg") || ext.equals(".png") || ext.equals(".gif"))) {
+            throw new CustomException(INVALID_IMAGE_FORMAT);
+        }
+    }
+
+
+    private String getFileExtension(String originalFilename) {
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            throw new CustomException(INVALID_FILE_FORMAT);
+        }
+        return originalFilename.substring(originalFilename.lastIndexOf("."));
+    }
+
+}

--- a/src/main/java/com/shcho/shBlog/common/service/S3Service.java
+++ b/src/main/java/com/shcho/shBlog/common/service/S3Service.java
@@ -24,6 +24,9 @@ public class S3Service {
     @Value("${minio.bucket}")
     private String bucket;
 
+    @Value("${custom.s3.url}")
+    private String minioBaseUrl;
+
     public FileUploadResponseDto uploadByType(MultipartFile file, String type, String username) {
         if ("image".equalsIgnoreCase(type)) {
             return uploadImage(file, type, username);
@@ -61,7 +64,7 @@ public class S3Service {
                             .build()
             );
 
-            String url = String.format("https://minio-api.csh980116.synology.me/shblog/%s", fileName);
+            String url = String.format("%s/%s/%s", minioBaseUrl, bucket, fileName);
             return FileUploadResponseDto.from(url);
         } catch (Exception e) {
             log.error("[Minio] 파일 업로드 실패:", e);

--- a/src/main/java/com/shcho/shBlog/common/service/S3Service.java
+++ b/src/main/java/com/shcho/shBlog/common/service/S3Service.java
@@ -4,12 +4,14 @@ import com.shcho.shBlog.common.dto.FileUploadResponseDto;
 import com.shcho.shBlog.libs.exception.CustomException;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
+import io.minio.RemoveObjectArgs;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.net.URI;
 import java.util.UUID;
 
 import static com.shcho.shBlog.libs.exception.ErrorCode.*;
@@ -34,6 +36,31 @@ public class S3Service {
             return uploadFile(file, type, username);
         } else {
             throw new CustomException(INVALID_FILE_TYPE);
+        }
+    }
+
+    public void deleteFileByUrl(String imageUrl) {
+        try {
+            URI uri = URI.create(imageUrl);
+            String path = uri.getPath();
+            String[] parts = path.split("/", 3);
+
+            if (parts.length < 3) {
+                throw new CustomException(INVALID_FILE_URL);
+            }
+
+            String bucketName = parts[1];
+            String objectName = parts[2];
+
+            minioClient.removeObject(
+                    RemoveObjectArgs.builder()
+                            .bucket(bucketName)
+                            .object(objectName)
+                            .build()
+            );
+            log.info("[Minio] 파일 삭제 성공: {}", objectName);
+        } catch (Exception e) {
+            log.error("[Minio] 파일 삭제 실패: {}", e.getMessage());
         }
     }
 

--- a/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
@@ -16,10 +16,16 @@ public enum ErrorCode {
     DUPLICATED_EMAIL(409, "USER_004", "이미 사용 중인 이메일입니다."),
     DUPLICATED_NICKNAME(409, "USER_005", "이미 사용 중인 닉네임입니다."),
 
+    /* 400 BAD_REQUEST */
+    INVALID_IMAGE_FORMAT(400, "FILE_001", "이미지 형식이 올바르지 않습니다. (jpg/jpeg/png/gif)"),
+    INVALID_FILE_FORMAT(400, "FILE_002", "파일 형식이 올바르지 않습니다."),
+    INVALID_FILE_TYPE(400, "FILE_003", "파일 타입이 잘못되었습니다."),
+
     /* 401 UNAUTHORIZED */
     INVALID_USERNAME_OR_PASSWORD(401, "AUTH_001", "아이디 또는 비밀번호가 올바르지 않습니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
+    FILE_UPLOAD_FAIL(500, "FILE_500", "파일 업로드에 실패했습니다."),
     INTERNAL_SERVER_ERROR(500, "COMMON_500", "서버 오류가 발생했습니다."),
     JWT_KEY_ERROR(500, "AUTH_500", "JWT 키가 유효하지 않습니다.");
 

--- a/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     DUPLICATED_USERNAME(409, "USER_003", "이미 사용 중인 아이디 입니다."),
     DUPLICATED_EMAIL(409, "USER_004", "이미 사용 중인 이메일입니다."),
     DUPLICATED_NICKNAME(409, "USER_005", "이미 사용 중인 닉네임입니다."),
+    DUPLICATE_CATEGORY_NAME(409, "CATEGORY_001", "이미 사용 중인 카테고리명입니다."),
 
     /* 400 BAD_REQUEST */
     INVALID_IMAGE_FORMAT(400, "FILE_001", "이미지 형식이 올바르지 않습니다. (jpg/jpeg/png/gif)"),
@@ -24,6 +25,12 @@ public enum ErrorCode {
 
     /* 401 UNAUTHORIZED */
     INVALID_USERNAME_OR_PASSWORD(401, "AUTH_001", "아이디 또는 비밀번호가 올바르지 않습니다."),
+
+    /* 403 FORBIDDEN */
+    FORBIDDEN_CATEGORY_DELETE(403, "CATEGORY_002", "해당 카테고리를 삭제할 권한이 없습니다."),
+
+    /* 404 NOT_FOUND */
+    CATEGORY_NOT_FOUND(404, "CATEGORY_003", "요청한 카테고리를 찾을 수 없습니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
     FILE_UPLOAD_FAIL(500, "FILE_500", "파일 업로드에 실패했습니다."),

--- a/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/shBlog/libs/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     INVALID_IMAGE_FORMAT(400, "FILE_001", "이미지 형식이 올바르지 않습니다. (jpg/jpeg/png/gif)"),
     INVALID_FILE_FORMAT(400, "FILE_002", "파일 형식이 올바르지 않습니다."),
     INVALID_FILE_TYPE(400, "FILE_003", "파일 타입이 잘못되었습니다."),
+    INVALID_FILE_URL(400, "FILE_004" , "파일 url이 잘못되었습니다." ),
 
     /* 401 UNAUTHORIZED */
     INVALID_USERNAME_OR_PASSWORD(401, "AUTH_001", "아이디 또는 비밀번호가 올바르지 않습니다."),

--- a/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
@@ -46,5 +46,5 @@ public class MyPageController {
         return ResponseEntity.ok("프로필 이미지 삭제 완료");
     }
 
-
+    // TODO :
 }

--- a/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
@@ -1,0 +1,50 @@
+package com.shcho.shBlog.myPage.controller;
+
+import com.shcho.shBlog.auth.CustomUserDetails;
+import com.shcho.shBlog.myPage.service.MyPageService;
+import com.shcho.shBlog.myPage.dto.UserInfoResponseDto;
+import com.shcho.shBlog.user.dto.UserProfileRequestDto;
+import com.shcho.shBlog.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/myPage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private MyPageService myPageService;
+
+    @GetMapping
+    public ResponseEntity<UserInfoResponseDto> getMyPage(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User user = userDetails.getUser();
+        UserInfoResponseDto responseDto = UserInfoResponseDto.from(user);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @PatchMapping("/profile")
+    public ResponseEntity<String> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserProfileRequestDto requestDto
+    ) {
+        Long userId = userDetails.getUser().getUserId();
+        myPageService.updateProfileImage(userId, requestDto.profileImageUrl());
+        return ResponseEntity.ok("프로필 이미지 등록 완료");
+    }
+
+    @DeleteMapping("/profile")
+    public ResponseEntity<String> deleteProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getUserId();
+        myPageService.deleteProfileImage(userId);
+        return ResponseEntity.ok("프로필 이미지 삭제 완료");
+    }
+
+
+}

--- a/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class MyPageController {
 
-    private MyPageService myPageService;
+    private final MyPageService myPageService;
 
     @GetMapping
     public ResponseEntity<UserInfoResponseDto> getMyPage(

--- a/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
+++ b/src/main/java/com/shcho/shBlog/myPage/controller/MyPageController.java
@@ -1,6 +1,7 @@
 package com.shcho.shBlog.myPage.controller;
 
 import com.shcho.shBlog.auth.CustomUserDetails;
+import com.shcho.shBlog.myPage.dto.UserPasswordUpdateRequestDto;
 import com.shcho.shBlog.myPage.service.MyPageService;
 import com.shcho.shBlog.myPage.dto.UserInfoResponseDto;
 import com.shcho.shBlog.user.dto.UserProfileRequestDto;
@@ -46,5 +47,32 @@ public class MyPageController {
         return ResponseEntity.ok("프로필 이미지 삭제 완료");
     }
 
-    // TODO :
+    @GetMapping("/nickname/check")
+    public ResponseEntity<Boolean> checkNickname(
+            @RequestParam String nickname
+    ) {
+        boolean exists = myPageService.existsByNickname(nickname);
+        return ResponseEntity.ok(exists);
+    }
+
+    @PatchMapping("/nickname")
+    public ResponseEntity<String> updateNickname(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam String nickname
+    ) {
+        Long userId = userDetails.getUser().getUserId();
+        myPageService.updateNickname(userId, nickname);
+
+        return ResponseEntity.ok("닉네임 변경이 완료 되었습니다.");
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<String> updatePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserPasswordUpdateRequestDto requestDto
+            ) {
+        Long userId = userDetails.getUser().getUserId();
+        myPageService.updatePassword(userId, requestDto.currentPassword(), requestDto.newPassword());
+        return ResponseEntity.ok("비밀번호 변경이 완료 되었습니다.");
+    }
 }

--- a/src/main/java/com/shcho/shBlog/myPage/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/myPage/dto/UserInfoResponseDto.java
@@ -1,4 +1,4 @@
-package com.shcho.shBlog.user.dto;
+package com.shcho.shBlog.myPage.dto;
 
 import com.shcho.shBlog.user.entity.User;
 

--- a/src/main/java/com/shcho/shBlog/myPage/dto/UserPasswordUpdateRequestDto.java
+++ b/src/main/java/com/shcho/shBlog/myPage/dto/UserPasswordUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package com.shcho.shBlog.myPage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserPasswordUpdateRequestDto(
+        @NotBlank String currentPassword,
+        @NotBlank String newPassword
+) {
+}

--- a/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
+++ b/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
@@ -1,11 +1,16 @@
 package com.shcho.shBlog.myPage.service;
 
 import com.shcho.shBlog.common.service.S3Service;
+import com.shcho.shBlog.libs.exception.CustomException;
+import com.shcho.shBlog.libs.exception.ErrorCode;
 import com.shcho.shBlog.user.entity.User;
 import com.shcho.shBlog.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.shcho.shBlog.libs.exception.ErrorCode.DUPLICATED_NICKNAME;
 
 @Service
 @RequiredArgsConstructor
@@ -13,6 +18,7 @@ public class MyPageService {
 
     private final UserRepository userRepository;
     private final S3Service s3Service;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public void updateProfileImage(Long userId, String newImageUrl) {
@@ -38,5 +44,32 @@ public class MyPageService {
         if(oldImageUrl != null && !oldImageUrl.isBlank()) {
             s3Service.deleteFileByUrl(oldImageUrl);
         }
+    }
+
+    public boolean existsByNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
+    @Transactional
+    public void updateNickname(Long userId, String newNickname) {
+        User user = userRepository.getReferenceById(userId);
+
+        if(userRepository.existsByNickname(newNickname)) {
+            throw new CustomException(DUPLICATED_NICKNAME);
+        }
+
+        user.updateNickname(newNickname);
+    }
+
+    @Transactional
+    public void updatePassword(Long userId, String currentPassword, String newPassword) {
+        User user = userRepository.getReferenceById(userId);
+
+        if(!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_USERNAME_OR_PASSWORD);
+        }
+
+        String encodedPassword = passwordEncoder.encode(newPassword);
+        user.updatePassword(encodedPassword);
     }
 }

--- a/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
+++ b/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
@@ -1,0 +1,42 @@
+package com.shcho.shBlog.myPage.service;
+
+import com.shcho.shBlog.common.service.S3Service;
+import com.shcho.shBlog.user.entity.User;
+import com.shcho.shBlog.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
+
+    @Transactional
+    public void updateProfileImage(Long userId, String newImageUrl) {
+        User user = userRepository.getReferenceById(userId);
+
+        deleteOldImageUrl(user);
+
+        user.updateProfileImageUrl(newImageUrl);
+    }
+
+    @Transactional
+    public void deleteProfileImage(Long userId) {
+        User user = userRepository.getReferenceById(userId);
+
+        deleteOldImageUrl(user);
+
+        user.deleteProfileImageUrl();
+    }
+
+    private void deleteOldImageUrl(User user) {
+        String oldImageUrl = user.getProfileImageUrl();
+
+        if(oldImageUrl != null && !oldImageUrl.isBlank()) {
+            s3Service.deleteFileByUrl(oldImageUrl);
+        }
+    }
+}

--- a/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
+++ b/src/main/java/com/shcho/shBlog/myPage/service/MyPageService.java
@@ -2,7 +2,6 @@ package com.shcho.shBlog.myPage.service;
 
 import com.shcho.shBlog.common.service.S3Service;
 import com.shcho.shBlog.libs.exception.CustomException;
-import com.shcho.shBlog.libs.exception.ErrorCode;
 import com.shcho.shBlog.user.entity.User;
 import com.shcho.shBlog.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.shcho.shBlog.libs.exception.ErrorCode.DUPLICATED_NICKNAME;
+import static com.shcho.shBlog.libs.exception.ErrorCode.INVALID_USERNAME_OR_PASSWORD;
 
 @Service
 @RequiredArgsConstructor
@@ -41,7 +41,7 @@ public class MyPageService {
     private void deleteOldImageUrl(User user) {
         String oldImageUrl = user.getProfileImageUrl();
 
-        if(oldImageUrl != null && !oldImageUrl.isBlank()) {
+        if (oldImageUrl != null && !oldImageUrl.isBlank()) {
             s3Service.deleteFileByUrl(oldImageUrl);
         }
     }
@@ -54,7 +54,7 @@ public class MyPageService {
     public void updateNickname(Long userId, String newNickname) {
         User user = userRepository.getReferenceById(userId);
 
-        if(userRepository.existsByNickname(newNickname)) {
+        if (userRepository.existsByNickname(newNickname)) {
             throw new CustomException(DUPLICATED_NICKNAME);
         }
 
@@ -65,8 +65,8 @@ public class MyPageService {
     public void updatePassword(Long userId, String currentPassword, String newPassword) {
         User user = userRepository.getReferenceById(userId);
 
-        if(!passwordEncoder.matches(currentPassword, user.getPassword())) {
-            throw new CustomException(ErrorCode.INVALID_USERNAME_OR_PASSWORD);
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new CustomException(INVALID_USERNAME_OR_PASSWORD);
         }
 
         String encodedPassword = passwordEncoder.encode(newPassword);

--- a/src/main/java/com/shcho/shBlog/user/controller/UserController.java
+++ b/src/main/java/com/shcho/shBlog/user/controller/UserController.java
@@ -1,18 +1,14 @@
 package com.shcho.shBlog.user.controller;
 
-import com.shcho.shBlog.user.dto.UserSignInRequestDto;
-import com.shcho.shBlog.user.dto.UserSignInResponseDto;
-import com.shcho.shBlog.user.dto.UserSignUpRequestDto;
-import com.shcho.shBlog.user.dto.UserSignUpResponseDto;
+import com.shcho.shBlog.auth.CustomUserDetails;
+import com.shcho.shBlog.user.dto.*;
 import com.shcho.shBlog.user.entity.User;
 import com.shcho.shBlog.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -40,6 +36,16 @@ public class UserController {
         String token = userService.getUserToken(user);
 
         UserSignInResponseDto responseDto = UserSignInResponseDto.of(user, token);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserInfoResponseDto> getMyInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User user = userDetails.getUser();
+        UserInfoResponseDto responseDto = UserInfoResponseDto.from(user);
 
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/com/shcho/shBlog/user/controller/UserController.java
+++ b/src/main/java/com/shcho/shBlog/user/controller/UserController.java
@@ -1,14 +1,18 @@
 package com.shcho.shBlog.user.controller;
 
-import com.shcho.shBlog.auth.CustomUserDetails;
-import com.shcho.shBlog.user.dto.*;
+import com.shcho.shBlog.user.dto.UserSignInRequestDto;
+import com.shcho.shBlog.user.dto.UserSignInResponseDto;
+import com.shcho.shBlog.user.dto.UserSignUpRequestDto;
+import com.shcho.shBlog.user.dto.UserSignUpResponseDto;
 import com.shcho.shBlog.user.entity.User;
 import com.shcho.shBlog.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -38,35 +42,6 @@ public class UserController {
         UserSignInResponseDto responseDto = UserSignInResponseDto.of(user, token);
 
         return ResponseEntity.ok(responseDto);
-    }
-
-    @GetMapping("/me")
-    public ResponseEntity<UserInfoResponseDto> getMyInfo(
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        User user = userDetails.getUser();
-        UserInfoResponseDto responseDto = UserInfoResponseDto.from(user);
-
-        return ResponseEntity.ok(responseDto);
-    }
-
-    @PatchMapping("/profile")
-    public ResponseEntity<String> updateProfile(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody UserProfileRequestDto requestDto
-    ) {
-        Long userId = userDetails.getUser().getUserId();
-        userService.updateProfileImage(userId, requestDto.profileImageUrl());
-        return ResponseEntity.ok("프로필 이미지 등록 완료");
-    }
-
-    @DeleteMapping("/profile")
-    public ResponseEntity<String> deleteProfile(
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        Long userId = userDetails.getUser().getUserId();
-        userService.deleteProfileImage(userId);
-        return ResponseEntity.ok("프로필 이미지 삭제 완료");
     }
 }
 

--- a/src/main/java/com/shcho/shBlog/user/controller/UserController.java
+++ b/src/main/java/com/shcho/shBlog/user/controller/UserController.java
@@ -49,5 +49,24 @@ public class UserController {
 
         return ResponseEntity.ok(responseDto);
     }
+
+    @PutMapping("/profile")
+    public ResponseEntity<String> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody UserProfileRequestDto requestDto
+    ) {
+        Long userId = userDetails.getUser().getUserId();
+        userService.updateProfileImage(userId, requestDto.profileImageUrl());
+        return ResponseEntity.ok("프로필 이미지 등록 완료");
+    }
+
+    @DeleteMapping("/profile")
+    public ResponseEntity<String> deleteProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getUserId();
+        userService.deleteProfileImage(userId);
+        return ResponseEntity.ok("프로필 이미지 삭제 완료");
+    }
 }
 

--- a/src/main/java/com/shcho/shBlog/user/controller/UserController.java
+++ b/src/main/java/com/shcho/shBlog/user/controller/UserController.java
@@ -50,7 +50,7 @@ public class UserController {
         return ResponseEntity.ok(responseDto);
     }
 
-    @PutMapping("/profile")
+    @PatchMapping("/profile")
     public ResponseEntity<String> updateProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody UserProfileRequestDto requestDto

--- a/src/main/java/com/shcho/shBlog/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/shcho/shBlog/user/dto/UserInfoResponseDto.java
@@ -1,0 +1,19 @@
+package com.shcho.shBlog.user.dto;
+
+import com.shcho.shBlog.user.entity.User;
+
+public record UserInfoResponseDto(
+        String username,
+        String nickname,
+        String email,
+        String profileImageUrl
+) {
+    public static UserInfoResponseDto from(User user) {
+        return new UserInfoResponseDto(
+                user.getUsername(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/shcho/shBlog/user/dto/UserProfileRequestDto.java
+++ b/src/main/java/com/shcho/shBlog/user/dto/UserProfileRequestDto.java
@@ -1,0 +1,8 @@
+package com.shcho.shBlog.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserProfileRequestDto(
+        @NotBlank String profileImageUrl
+) {
+}

--- a/src/main/java/com/shcho/shBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/shBlog/user/entity/User.java
@@ -35,7 +35,7 @@ public class User extends BaseEntity {
     private String email;
 
     @Column
-    String profileImageUrl;
+    private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(50)")

--- a/src/main/java/com/shcho/shBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/shBlog/user/entity/User.java
@@ -97,9 +97,4 @@ public class User extends BaseEntity {
     public boolean isDeleted() {
         return this.deletedAt != null;
     }
-
-    public void addCategory(Category category) {
-        categories.add(category);
-        category.setUser(this);
-    }
 }

--- a/src/main/java/com/shcho/shBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/shBlog/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.shcho.shBlog.user.entity;
 
+import com.shcho.shBlog.category.entity.Category;
 import com.shcho.shBlog.common.entity.BaseEntity;
 import com.shcho.shBlog.libs.exception.CustomException;
 import com.shcho.shBlog.libs.exception.ErrorCode;
@@ -10,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Builder
@@ -40,6 +42,10 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(50)")
     private Role role;
+
+    // 추후 유저 탈퇴 고려 시 cascade = CascadeType.ALL, orphanRemoval = true 옵션 추가
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<Category> categories;
 
     @Column
     private LocalDateTime deletedAt;
@@ -90,5 +96,10 @@ public class User extends BaseEntity {
 
     public boolean isDeleted() {
         return this.deletedAt != null;
+    }
+
+    public void addCategory(Category category) {
+        categories.add(category);
+        category.setUser(this);
     }
 }

--- a/src/main/java/com/shcho/shBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/shBlog/user/entity/User.java
@@ -74,6 +74,10 @@ public class User extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public void deleteProfileImageUrl() {
+        this.profileImageUrl = null;
+    }
+
     public void withdraw() {
         if (this.deletedAt != null) {
             throw new CustomException(ErrorCode.ALREADY_DELETED_USER);

--- a/src/main/java/com/shcho/shBlog/user/service/UserService.java
+++ b/src/main/java/com/shcho/shBlog/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.shcho.shBlog.user.service;
 
-import com.shcho.shBlog.common.service.S3Service;
 import com.shcho.shBlog.common.util.JwtProvider;
 import com.shcho.shBlog.libs.exception.CustomException;
 import com.shcho.shBlog.user.dto.UserSignInRequestDto;
@@ -22,7 +21,6 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
-    private final S3Service s3Service;
 
     @Transactional
     public User signUp(@Valid UserSignUpRequestDto requestDto) {
@@ -74,31 +72,6 @@ public class UserService {
         return !passwordEncoder.matches(password, user.getPassword());
     }
 
-    @Transactional
-    public void updateProfileImage(Long userId, String newImageUrl) {
-        User user = userRepository.getReferenceById(userId);
-
-        deleteOldImageUrl(user);
-
-        user.updateProfileImageUrl(newImageUrl);
-    }
-
-    @Transactional
-    public void deleteProfileImage(Long userId) {
-        User user = userRepository.getReferenceById(userId);
-
-        deleteOldImageUrl(user);
-
-        user.deleteProfileImageUrl();
-    }
-
-    private void deleteOldImageUrl(User user) {
-        String oldImageUrl = user.getProfileImageUrl();
-
-        if(oldImageUrl != null && !oldImageUrl.isBlank()) {
-            s3Service.deleteFileByUrl(oldImageUrl);
-        }
-    }
 
     public String getUserToken(User user) {
         return jwtProvider.createToken(user.getUsername(), user.getRole());

--- a/src/main/java/com/shcho/shBlog/user/service/UserService.java
+++ b/src/main/java/com/shcho/shBlog/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.shcho.shBlog.user.service;
 
+import com.shcho.shBlog.common.service.S3Service;
 import com.shcho.shBlog.common.util.JwtProvider;
 import com.shcho.shBlog.libs.exception.CustomException;
 import com.shcho.shBlog.user.dto.UserSignInRequestDto;
@@ -21,6 +22,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final S3Service s3Service;
 
     @Transactional
     public User signUp(@Valid UserSignUpRequestDto requestDto) {
@@ -70,6 +72,32 @@ public class UserService {
     private boolean isUnmatchedPassword(String username, String password) {
         User user = userRepository.getReferenceByUsername(username);
         return !passwordEncoder.matches(password, user.getPassword());
+    }
+
+    @Transactional
+    public void updateProfileImage(Long userId, String newImageUrl) {
+        User user = userRepository.getReferenceById(userId);
+
+        deleteOldImageUrl(user);
+
+        user.updateProfileImageUrl(newImageUrl);
+    }
+
+    @Transactional
+    public void deleteProfileImage(Long userId) {
+        User user = userRepository.getReferenceById(userId);
+
+        deleteOldImageUrl(user);
+
+        user.deleteProfileImageUrl();
+    }
+
+    private void deleteOldImageUrl(User user) {
+        String oldImageUrl = user.getProfileImageUrl();
+
+        if(oldImageUrl != null && !oldImageUrl.isBlank()) {
+            s3Service.deleteFileByUrl(oldImageUrl);
+        }
     }
 
     public String getUserToken(User user) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,12 @@ spring:
         format_sql: true
         show_sql: true
 
+minio:
+  url: ${MINIO_URL}
+  access-key: ${MINIO_ACCESS_KEY}
+  secret-key: ${MINIO_SECRET_KEY}
+  bucket: shblog
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,7 @@ logging:
 
 jwt:
   secret: ${JWT_SECRET}
+
+custom:
+  s3:
+    url: https://minio.boottalk.site

--- a/src/test/java/com/shcho/shBlog/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/category/service/CategoryServiceTest.java
@@ -1,0 +1,181 @@
+package com.shcho.shBlog.category.service;
+
+import com.shcho.shBlog.category.dto.CreateCategoryRequestDto;
+import com.shcho.shBlog.category.entity.Category;
+import com.shcho.shBlog.category.repository.CategoryRepository;
+import com.shcho.shBlog.libs.exception.CustomException;
+import com.shcho.shBlog.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.shcho.shBlog.libs.exception.ErrorCode.*;
+import static com.shcho.shBlog.user.entity.Role.USER;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("Category Service Unit Test")
+class CategoryServiceTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    public CategoryServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 성공")
+    void createCategorySuccess() {
+        // given
+        Long userId = 1L;
+
+        User user = User.builder()
+                .userId(userId)
+                .username("userName")
+                .nickname("nickname")
+                .password("encodedPassword")
+                .role(USER)
+                .build();
+
+        CreateCategoryRequestDto requestDto = new CreateCategoryRequestDto("name", "description");
+
+        when(categoryRepository.existsByUser_UserIdAndName(user.getUserId(), requestDto.name()))
+                .thenReturn(false);
+
+        // when
+        Category newCategory = categoryService.createCategory(user, requestDto);
+
+        // then
+        assertNotNull(newCategory);
+        assertEquals(user.getUserId(), newCategory.getUser().getUserId());
+        assertEquals(requestDto.name(), newCategory.getName());
+        assertEquals(requestDto.description(), newCategory.getDescription());
+        verify(categoryRepository, times(1)).existsByUser_UserIdAndName(user.getUserId(), requestDto.name());
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 실패 - 이미 존재하는 카테고리 이름")
+    void createCategoryFailedDuplicateCategoryName() {
+        // given
+        User user = User.builder()
+                .userId(1L)
+                .role(USER)
+                .build();
+
+        CreateCategoryRequestDto requestDto = new CreateCategoryRequestDto("existsCategory", "description");
+        when(categoryRepository.existsByUser_UserIdAndName(user.getUserId(), requestDto.name()))
+                .thenReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> categoryService.createCategory(user, requestDto));
+
+        assertEquals(DUPLICATE_CATEGORY_NAME, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("유저의 모든 카테고리 조회 성공")
+    void getAllCategoriesSuccess() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .userId(userId)
+                .role(USER)
+                .build();
+
+        List<Category> mockCategories = List.of(
+                Category.of(user, "카테고리1", "설명1"),
+                Category.of(user, "카테고리2", "설명2")
+        );
+
+        when(categoryRepository.findAllByUser_UserIdOrderByNameAsc(userId))
+                .thenReturn(mockCategories);
+
+        // when
+        List<Category> result = categoryService.getAllCategories(user);
+
+        // then
+        assertEquals(2, result.size());
+        assertEquals("카테고리1", result.get(0).getName());
+        verify(categoryRepository, times(1)).findAllByUser_UserIdOrderByNameAsc(userId);
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 성공")
+    void deleteCategorySuccess() {
+        // given
+        Long userId = 1L;
+        Long categoryId = 10L;
+
+        User user = User.builder()
+                .userId(userId)
+                .role(USER)
+                .build();
+
+        Category category = Category.of(user, "testCategory", "description");
+
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+
+        // when
+        categoryService.deleteCategoryByCategoryId(user, categoryId);
+
+        // then
+        verify(categoryRepository, times(1)).delete(category);
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 실패 - 존재하지 않는 카테고리")
+    void deleteCategoryFailedCategoryNotFound() {
+        // given
+        Long categoryId = 999L;
+        User user = User.builder()
+                .userId(1L)
+                .role(USER)
+                .build();
+
+        when(categoryRepository.findById(categoryId)).thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> categoryService.deleteCategoryByCategoryId(user, categoryId));
+
+        assertEquals(CATEGORY_NOT_FOUND, exception.getErrorCode());
+        verify(categoryRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 실패 - 카테고리의 소유 유저 불일치")
+    void deleteCategoryFailedForbiddenCategory() {
+        // given
+        User categoryOwner = User.builder()
+                .userId(1L)
+                .role(USER)
+                .build();
+
+        User anotherUser = User.builder()
+                .userId(2L)
+                .role(USER)
+                .build();
+
+        Category category = Category.of(categoryOwner, "카테고리", "설명");
+
+        when(categoryRepository.findById(anyLong()))
+                .thenReturn(java.util.Optional.of(category));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> categoryService.deleteCategoryByCategoryId(anotherUser, 1L));
+
+        assertEquals(FORBIDDEN_CATEGORY_DELETE, exception.getErrorCode());
+        verify(categoryRepository, never()).delete(any());
+    }
+}

--- a/src/test/java/com/shcho/shBlog/myPage/service/MyPageServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/myPage/service/MyPageServiceTest.java
@@ -1,6 +1,7 @@
 package com.shcho.shBlog.myPage.service;
 
 import com.shcho.shBlog.common.service.S3Service;
+import com.shcho.shBlog.libs.exception.CustomException;
 import com.shcho.shBlog.user.entity.User;
 import com.shcho.shBlog.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -8,13 +9,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static com.shcho.shBlog.libs.exception.ErrorCode.DUPLICATED_NICKNAME;
+import static com.shcho.shBlog.libs.exception.ErrorCode.INVALID_USERNAME_OR_PASSWORD;
 import static com.shcho.shBlog.user.entity.Role.USER;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.never;
 
 @DisplayName("MyPage Service Unit Test")
 class MyPageServiceTest {
@@ -24,6 +26,9 @@ class MyPageServiceTest {
 
     @Mock
     private S3Service s3Service;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @InjectMocks
     private MyPageService myPageService;
@@ -136,5 +141,132 @@ class MyPageServiceTest {
         // then
         verify(s3Service, never()).deleteFileByUrl(anyString());
         assertNull(user.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 확인")
+    void existsNicknameSuccess() {
+        // given
+        String nickname = "existsNickname";
+        when(userRepository.existsByNickname(nickname)).thenReturn(true);
+
+        // when
+        boolean exists = myPageService.existsByNickname(nickname);
+
+        // then
+        assertTrue(exists);
+        verify(userRepository, times(1)).existsByNickname(nickname);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 성공")
+    void updateNicknameSuccess() {
+        // given
+        Long userId = 1L;
+        String newNickname = "newNickname";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("userName")
+                .nickname("oldNickname")
+                .password("encodedPassword")
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+        when(userRepository.existsByNickname(newNickname)).thenReturn(false);
+
+        // when
+        myPageService.updateNickname(userId, newNickname);
+
+        // then
+        assertEquals(newNickname, user.getNickname());
+        verify(userRepository, times(1)).existsByNickname(newNickname);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 실패 - 중복된 닉네임")
+    void updateNicknameFailedDuplicatedNickname() {
+        // given
+        Long userId = 1L;
+        String existsNickname = "existsNickname";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("userName")
+                .nickname("oldNickname")
+                .password("encodedPassword")
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+        when(userRepository.existsByNickname(existsNickname)).thenReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> myPageService.updateNickname(userId, existsNickname));
+
+        assertEquals(DUPLICATED_NICKNAME, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 성공")
+    void updatePasswordSuccess() {
+        // given
+        Long userId = 1L;
+        String oldPassword = "oldPassword";
+        String newPassword = "newPassword";
+
+        String encodedOldPassword = "encodedOldPassword";
+        String encodedNewPassword = "encodedNewPassword";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .password(encodedOldPassword)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+        when(passwordEncoder.matches(oldPassword, user.getPassword())).thenReturn(true);
+        when(passwordEncoder.encode(newPassword)).thenReturn("encodedNewPassword");
+
+        // when
+        myPageService.updatePassword(userId, oldPassword, newPassword);
+
+        // then
+        assertEquals(encodedNewPassword, user.getPassword());
+        verify(passwordEncoder).matches(oldPassword, encodedOldPassword);
+        verify(passwordEncoder).encode(newPassword);
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - 비밀번호 불일치")
+    void updatePasswordFailedUnmatchedPassword() {
+        // given
+        Long userId = 1L;
+        String oldPassword = "oldPassword";
+        String newPassword = "newPassword";
+
+        String encodedOldPassword = passwordEncoder.encode(oldPassword);
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .password(encodedOldPassword)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+        when(passwordEncoder.matches(oldPassword, user.getPassword())).thenReturn(false);
+
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> myPageService.updatePassword(userId, oldPassword, newPassword));
+
+        assertEquals(INVALID_USERNAME_OR_PASSWORD, exception.getErrorCode());
     }
 }

--- a/src/test/java/com/shcho/shBlog/myPage/service/MyPageServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/myPage/service/MyPageServiceTest.java
@@ -1,0 +1,140 @@
+package com.shcho.shBlog.myPage.service;
+
+import com.shcho.shBlog.common.service.S3Service;
+import com.shcho.shBlog.user.entity.User;
+import com.shcho.shBlog.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static com.shcho.shBlog.user.entity.Role.USER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+
+@DisplayName("MyPage Service Unit Test")
+class MyPageServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private MyPageService myPageService;
+
+    public MyPageServiceTest() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업데이트 성공")
+    void updateUserProfileImageSuccess() {
+        // given
+        Long userId = 1L;
+        String newImageUrl = "www.minio.com/new.jpg";
+        String oldImageUrl = "www.minio.com/old.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(oldImageUrl)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        myPageService.updateProfileImage(userId, newImageUrl);
+
+        // then
+        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
+        assertEquals(newImageUrl, user.getProfileImageUrl());
+
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업데이트 성공 - 기존 이미지 없음")
+    void updateUserProfileImageWithoutOldImage() {
+        // given
+        Long userId = 1L;
+        String newImageUrl = "www.minio.com/new.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(null)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        myPageService.updateProfileImage(userId, newImageUrl);
+        verify(s3Service, never()).deleteFileByUrl(newImageUrl);
+    }
+
+    @Test
+    @DisplayName("프로필 사진 삭제 성공")
+    void deleteUserProfileImageSuccess() {
+        // given
+        Long userId = 1L;
+        String oldImageUrl = "www.minio.com/old.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(oldImageUrl)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        myPageService.deleteProfileImage(userId);
+
+        // then
+        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
+        assertNull(user.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("프로필 사진 삭제 - 기존 이미지 없음")
+    void deleteUserProfileImageWithoutOldImage() {
+        // given
+        Long userId = 1L;
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(null) // 이미지 없음
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        myPageService.deleteProfileImage(userId);
+
+        // then
+        verify(s3Service, never()).deleteFileByUrl(anyString());
+        assertNull(user.getProfileImageUrl());
+    }
+}

--- a/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.shcho.shBlog.user.service;
 
+import com.shcho.shBlog.common.service.S3Service;
 import com.shcho.shBlog.libs.exception.CustomException;
 import com.shcho.shBlog.libs.exception.ErrorCode;
 import com.shcho.shBlog.user.dto.UserSignInRequestDto;
@@ -17,8 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static com.shcho.shBlog.libs.exception.ErrorCode.*;
 import static com.shcho.shBlog.user.entity.Role.USER;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @DisplayName("User Service Unit Test")
@@ -29,6 +29,9 @@ class UserServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private S3Service s3Service;
 
     @InjectMocks
     private UserService userService;
@@ -203,5 +206,111 @@ class UserServiceTest {
 
     private UserSignInRequestDto createSignInRequest(String username, String password) {
         return new UserSignInRequestDto(username, password);
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업데이트 성공")
+    void updateUserProfileImageSuccess() {
+        // given
+        Long userId = 1L;
+        String newImageUrl = "www.minio.com/new.jpg";
+        String oldImageUrl = "www.minio.com/old.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(oldImageUrl)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        userService.updateProfileImage(userId, newImageUrl);
+
+        // then
+        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
+        assertEquals(newImageUrl, user.getProfileImageUrl());
+
+    }
+
+    @Test
+    @DisplayName("프로필 사진 업데이트 성공 - 기존 이미지 없음")
+    void updateUserProfileImageWithoutOldImage() {
+        // given
+        Long userId = 1L;
+        String newImageUrl = "www.minio.com/new.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(null)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        userService.updateProfileImage(userId, newImageUrl);
+        verify(s3Service, never()).deleteFileByUrl(newImageUrl);
+    }
+
+    @Test
+    @DisplayName("프로필 사진 삭제 성공")
+    void deleteUserProfileImageSuccess() {
+        // given
+        Long userId = 1L;
+        String oldImageUrl = "www.minio.com/old.jpg";
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(oldImageUrl)
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        userService.deleteProfileImage(userId);
+
+        // then
+        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
+        assertNull(user.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("프로필 사진 삭제 - 기존 이미지 없음")
+    void deleteUserProfileImageWithoutOldImage() {
+        // given
+        Long userId = 1L;
+
+        User user = User.builder()
+                .userId(userId)
+                .username("existsUsername")
+                .nickname("test")
+                .email("test@email.com")
+                .password("encodedPassword")
+                .profileImageUrl(null) // 이미지 없음
+                .role(USER)
+                .build();
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        // when
+        userService.deleteProfileImage(userId);
+
+        // then
+        verify(s3Service, never()).deleteFileByUrl(anyString());
+        assertNull(user.getProfileImageUrl());
     }
 }

--- a/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
@@ -1,11 +1,8 @@
 package com.shcho.shBlog.user.service;
 
-import com.shcho.shBlog.common.service.S3Service;
 import com.shcho.shBlog.libs.exception.CustomException;
-import com.shcho.shBlog.libs.exception.ErrorCode;
 import com.shcho.shBlog.user.dto.UserSignInRequestDto;
 import com.shcho.shBlog.user.dto.UserSignUpRequestDto;
-import com.shcho.shBlog.user.entity.Role;
 import com.shcho.shBlog.user.entity.User;
 import com.shcho.shBlog.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +15,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static com.shcho.shBlog.libs.exception.ErrorCode.*;
 import static com.shcho.shBlog.user.entity.Role.USER;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @DisplayName("User Service Unit Test")

--- a/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
+++ b/src/test/java/com/shcho/shBlog/user/service/UserServiceTest.java
@@ -30,9 +30,6 @@ class UserServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
-    @Mock
-    private S3Service s3Service;
-
     @InjectMocks
     private UserService userService;
 
@@ -208,109 +205,5 @@ class UserServiceTest {
         return new UserSignInRequestDto(username, password);
     }
 
-    @Test
-    @DisplayName("프로필 사진 업데이트 성공")
-    void updateUserProfileImageSuccess() {
-        // given
-        Long userId = 1L;
-        String newImageUrl = "www.minio.com/new.jpg";
-        String oldImageUrl = "www.minio.com/old.jpg";
 
-        User user = User.builder()
-                .userId(userId)
-                .username("existsUsername")
-                .nickname("test")
-                .email("test@email.com")
-                .password("encodedPassword")
-                .profileImageUrl(oldImageUrl)
-                .role(USER)
-                .build();
-
-        when(userRepository.getReferenceById(userId)).thenReturn(user);
-
-        // when
-        userService.updateProfileImage(userId, newImageUrl);
-
-        // then
-        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
-        assertEquals(newImageUrl, user.getProfileImageUrl());
-
-    }
-
-    @Test
-    @DisplayName("프로필 사진 업데이트 성공 - 기존 이미지 없음")
-    void updateUserProfileImageWithoutOldImage() {
-        // given
-        Long userId = 1L;
-        String newImageUrl = "www.minio.com/new.jpg";
-
-        User user = User.builder()
-                .userId(userId)
-                .username("existsUsername")
-                .nickname("test")
-                .email("test@email.com")
-                .password("encodedPassword")
-                .profileImageUrl(null)
-                .role(USER)
-                .build();
-
-        when(userRepository.getReferenceById(userId)).thenReturn(user);
-
-        // when
-        userService.updateProfileImage(userId, newImageUrl);
-        verify(s3Service, never()).deleteFileByUrl(newImageUrl);
-    }
-
-    @Test
-    @DisplayName("프로필 사진 삭제 성공")
-    void deleteUserProfileImageSuccess() {
-        // given
-        Long userId = 1L;
-        String oldImageUrl = "www.minio.com/old.jpg";
-
-        User user = User.builder()
-                .userId(userId)
-                .username("existsUsername")
-                .nickname("test")
-                .email("test@email.com")
-                .password("encodedPassword")
-                .profileImageUrl(oldImageUrl)
-                .role(USER)
-                .build();
-
-        when(userRepository.getReferenceById(userId)).thenReturn(user);
-
-        // when
-        userService.deleteProfileImage(userId);
-
-        // then
-        verify(s3Service, times(1)).deleteFileByUrl(oldImageUrl);
-        assertNull(user.getProfileImageUrl());
-    }
-
-    @Test
-    @DisplayName("프로필 사진 삭제 - 기존 이미지 없음")
-    void deleteUserProfileImageWithoutOldImage() {
-        // given
-        Long userId = 1L;
-
-        User user = User.builder()
-                .userId(userId)
-                .username("existsUsername")
-                .nickname("test")
-                .email("test@email.com")
-                .password("encodedPassword")
-                .profileImageUrl(null) // 이미지 없음
-                .role(USER)
-                .build();
-
-        when(userRepository.getReferenceById(userId)).thenReturn(user);
-
-        // when
-        userService.deleteProfileImage(userId);
-
-        // then
-        verify(s3Service, never()).deleteFileByUrl(anyString());
-        assertNull(user.getProfileImageUrl());
-    }
 }


### PR DESCRIPTION
## 🔀 PR 제목
[Feat] Category 엔티티 및 CRUD 기능 및 단위 테스트 구현

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 요약해서 적어주세요 -->
- Category 엔티티 설계 및 User 연관관계 설정 (ManyToOne)
- CategoryRepository, Service, Controller 구현
- 카테고리 생성 시 중복 이름 검사 및 삭제 시 권한 검증 로직 추가
- CreateCategoryRequestDto / CreateCategoryResponseDto 작성
- CategoryServiceTest 단위 테스트 작성 (Mockito 기반, 총 6개 케이스 통과)

## 🔧 변경사항
<!-- 어떤 파일이 추가/수정/삭제되었는지 -->
- `Category.java` (엔티티)
- `CategoryRepository.java`
- `CategoryService.java`
- `CategoryController.java`
- `CreateCategoryRequestDto.java`
- `CreateCategoryResponseDto.java`
- `CategoryServiceTest.java`

## 📌 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요 -->
- close #20 
